### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ dependencies = [
     "tornado~=3.2.1",
     "pint",
 ]
-name = "pyobd"
+name = "pyobd2"
 version = "1.15"
-description = "Open source OBD car diagnostics program - reuploaded"
+description = "Open source OBD-II car diagnostics program - reuploaded"
 authors = [{ "name" = "Jure Poljsak" }, { "name" = "Charles Donour Sizemore" }]
 readme = "README.md"
 license = { file = "COPYING" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+dependencies = [
+    "wxpython~=4.1.1",
+    "pyserial~=3.5",
+    "numpy~=1.23",
+    "tornado~=3.2.1",
+    "pint",
+]
+name = "pyobd"
+version = "1.15"
+description = "Open source OBD car diagnostics program - reuploaded"
+authors = [{ "name" = "Jure Poljsak" }, { "name" = "Charles Donour Sizemore" }]
+readme = "README.md"
+license = { file = "COPYING" }
+requires-python = ">=3.8"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #5

Bare pyproject.toml file.
As there is no build system attached to the current repository, it uses the [build](https://pypi.org/project/build/) system recommended in the setuptools documentation.

The minimal python version is debatable.