### PR TITLE
fixes reading DTCs on can

### DIFF
--- a/obd/decoders.py
+++ b/obd/decoders.py
@@ -432,7 +432,7 @@ def dtc(messages):
         if message.can == False:
             d += message.data[2:]
         elif message.can and message.num_frames == 1:
-            d += message.data[1:]  # remove the mode and DTC_count bytes
+            d += message.data[2:]  # remove the mode and DTC_count bytes
         elif message.can and message.num_frames > 1:
             d += message.data[0:]  # remove the mode and DTC_count bytes
     print(d)


### PR DESCRIPTION
tested with https://github.com/Ircama/ELM327-emulator (manually added DTCs, because it comes without any out-of-the-box) and Audi A3 with confirmed code. Also checked and confirmed against output from OBD Auto Doctor

Be warned, not sure if I killed anything else with this fix!